### PR TITLE
ASDK-504 Playing Playready protected content

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
+++ b/library/src/main/java/com/google/android/exoplayer/MediaCodecTrackRenderer.java
@@ -540,7 +540,16 @@ public abstract class MediaCodecTrackRenderer extends SampleSourceTrackRenderer 
     }
 
     if (inputIndex < 0) {
-      inputIndex = codec.dequeueInputBuffer(0);
+      try {
+        inputIndex = codec.dequeueInputBuffer(0);
+      }catch (Exception e){
+        // Workaround for issue in Amazon FireTV which throws an
+        // 'android.media.MediaCodec$CodecException: Error 0xffffffea' exception here. We catch
+        // it and try to restart the decoder.
+        releaseCodec();
+        maybeInitCodec();
+        return false;
+      }
       if (inputIndex < 0) {
         return false;
       }
@@ -813,7 +822,16 @@ public abstract class MediaCodecTrackRenderer extends SampleSourceTrackRenderer 
     }
 
     if (outputIndex < 0) {
-      outputIndex = codec.dequeueOutputBuffer(outputBufferInfo, getDequeueOutputBufferTimeoutUs());
+      try {
+        outputIndex = codec.dequeueOutputBuffer(outputBufferInfo, getDequeueOutputBufferTimeoutUs());
+      }catch (Exception e){
+        // Workaround for issue in Amazon FireTV which throws an
+        // 'android.media.MediaCodec$CodecException: Error 0xffffffea' exception here. We catch
+        // it and try to restart the decoder.
+        releaseCodec();
+        maybeInitCodec();
+        return false;
+      }
     }
 
     if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {


### PR DESCRIPTION
On a FireTV with Fire OS 5, when playing Playready protected content, the
MediaCodec raises exception before playback. This workaround catches the
exceptions and restarts the MediaCodec, which fixes the issue.