### PR TITLE
Live edge calculation alignment

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -730,7 +730,7 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
   private long getLiveEdgeUs(int variantIndex) {
     HlsMediaPlaylist mediaPlaylist = variantPlaylists[variantIndex];
     int size = mediaPlaylist.segments.size();
-    return size > 3 ? mediaPlaylist.segments.get(size - 20).startTimeUs : 0;
+    return size > 3 ? mediaPlaylist.segments.get(size - 3).startTimeUs : 0;
   }
 
   private int getLiveEdgeIndex(int variantIndex) {


### PR DESCRIPTION
In the HlsChunkSource there are two methods to calculate the HLS live edge. One of them has recently been updated (in commit 4726da4). This changed the Live Edge to be calculated based on the 3rd latest segment. For some reason, it has only been changed in one of the two methods.

The method HlsChunkSource.getLiveEdgeIndex(int) still calculates the live edge based on the 20th lastest segment, which is now inconsistent with the getLiveEdgeIndex(int) method. 
This pull request aligns both methods to make sure both methods calculate the live edge based on the same segment. 

This will also allow the user to seek to newer video segments. It fixes the gap between the live video position and the maximum seek position. Without this pull request, it's impossible to seek to the 10th latest segment, although the user is able to view the 3rd last and 20th+ last segments.