### PR TITLE
Parses the name for muxed audio tracks

### DIFF
--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsChunkSource.java
@@ -290,7 +290,7 @@ public class HlsChunkSource implements HlsTrackSelector.Output {
       List<Variant> variants = new ArrayList<>();
       variants.add(new Variant(baseUri, format));
       masterPlaylist = new HlsMasterPlaylist(baseUri, variants,
-          Collections.<Variant>emptyList(), Collections.<Variant>emptyList(), null, null);
+          Collections.<Variant>emptyList(), Collections.<Variant>emptyList(), null, null, null);
     }
   }
 

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsMasterPlaylist.java
@@ -29,15 +29,17 @@ public final class HlsMasterPlaylist extends HlsPlaylist {
 
   public final String muxedAudioLanguage;
   public final String muxedCaptionLanguage;
+  public final String muxedAudioName;
 
   public HlsMasterPlaylist(String baseUri, List<Variant> variants,
       List<Variant> audios, List<Variant> subtitles, String muxedAudioLanguage,
-      String muxedCaptionLanguage) {
+      String muxedAudioName, String muxedCaptionLanguage) {
     super(baseUri, HlsPlaylist.TYPE_MASTER);
     this.variants = Collections.unmodifiableList(variants);
     this.audios = Collections.unmodifiableList(audios);
     this.subtitles = Collections.unmodifiableList(subtitles);
     this.muxedAudioLanguage = muxedAudioLanguage;
+    this.muxedAudioName = muxedAudioName;
     this.muxedCaptionLanguage = muxedCaptionLanguage;
   }
 

--- a/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
+++ b/library/src/main/java/com/google/android/exoplayer/hls/HlsPlaylistParser.java
@@ -151,6 +151,7 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
     int height = -1;
     String name = null;
     String muxedAudioLanguage = null;
+    String muxedAudioName = null;
     String muxedCaptionLanguage = null;
 
     boolean expectingStreamInfUrl = false;
@@ -177,13 +178,14 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
           // We assume all audios belong to the same group.
           String language = HlsParserUtil.parseOptionalStringAttr(line, LANGUAGE_ATTR_REGEX);
           String uri = HlsParserUtil.parseOptionalStringAttr(line, URI_ATTR_REGEX);
+          String audioName = HlsParserUtil.parseOptionalStringAttr(line, NAME_ATTR_REGEX);;
           if (uri != null) {
-            String audioName = HlsParserUtil.parseStringAttr(line, NAME_ATTR_REGEX, NAME_ATTR);
             Format format = new Format(audioName, MimeTypes.APPLICATION_M3U8, -1, -1, -1, -1, -1,
                 -1, language, codecs);
             audios.add(new Variant(uri, format));
           } else {
             muxedAudioLanguage = language;
+            muxedAudioName = audioName;
           }
         }
       } else if (line.startsWith(STREAM_INF_TAG)) {
@@ -225,7 +227,7 @@ public final class HlsPlaylistParser implements UriLoadable.Parser<HlsPlaylist> 
       }
     }
     return new HlsMasterPlaylist(baseUri, variants, audios, subtitles, muxedAudioLanguage,
-        muxedCaptionLanguage);
+      muxedAudioName, muxedCaptionLanguage);
   }
 
   private static HlsMediaPlaylist parseMediaPlaylist(LineIterator iterator, String baseUri)


### PR DESCRIPTION
Before this patch, the HLS playlist parser was only extracting the language of
a muxed audio track. This patch extends the behavior and the parser now also
extracts the name of the audio track and passes it along to the master
playlist.