### PR TITLE
Add support to seek in local mp4 files without SIDX boxes

### DIFF
--- a/library/src/androidTest/java/com/google/android/exoplayer/testutil/FakeExtractorInput.java
+++ b/library/src/androidTest/java/com/google/android/exoplayer/testutil/FakeExtractorInput.java
@@ -15,10 +15,11 @@
  */
 package com.google.android.exoplayer.testutil;
 
+import android.util.SparseBooleanArray;
+
 import com.google.android.exoplayer.C;
 import com.google.android.exoplayer.extractor.ExtractorInput;
-
-import android.util.SparseBooleanArray;
+import com.google.android.exoplayer.upstream.DataSource;
 
 import junit.framework.Assert;
 
@@ -192,8 +193,13 @@ public final class FakeExtractorInput implements ExtractorInput {
     return simulateUnknownLength ? C.LENGTH_UNBOUNDED : data.length;
   }
 
+  @Override
+  public DataSource getDataSource() {
+    return null;
+  }
+
   private boolean checkXFully(boolean allowEndOfInput, int position, int length,
-      SparseBooleanArray failedPositions) throws IOException {
+                              SparseBooleanArray failedPositions) throws IOException {
     if (simulateIOErrors && !failedPositions.get(position)) {
       failedPositions.put(position, true);
       peekPosition = readPosition;

--- a/library/src/main/java/com/google/android/exoplayer/extractor/DefaultExtractorInput.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/DefaultExtractorInput.java
@@ -162,6 +162,11 @@ public final class DefaultExtractorInput implements ExtractorInput {
     return streamLength;
   }
 
+  @Override
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+
   /**
    * Ensures {@code peekBuffer} is large enough to store at least {@code length} bytes from the
    * current peek position.

--- a/library/src/main/java/com/google/android/exoplayer/extractor/ExtractorInput.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/ExtractorInput.java
@@ -16,6 +16,7 @@
 package com.google.android.exoplayer.extractor;
 
 import com.google.android.exoplayer.C;
+import com.google.android.exoplayer.upstream.DataSource;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -222,5 +223,12 @@ public interface ExtractorInput {
    * @return The length of the source stream, or {@link C#LENGTH_UNBOUNDED}.
    */
   long getLength();
+
+  /**
+   * Returns the data source of this Extractor input or null.
+   *
+   * @return The data source of this Extractor input or null
+   */
+  DataSource getDataSource();
 
 }

--- a/library/src/main/java/com/google/android/exoplayer/extractor/mp4/Atom.java
+++ b/library/src/main/java/com/google/android/exoplayer/extractor/mp4/Atom.java
@@ -128,6 +128,9 @@ import java.util.List;
   public static final int TYPE_vpcc = Util.getIntegerCodeForString("vpcC");
   public static final int TYPE_vp09 = Util.getIntegerCodeForString("vp09");
   public static final int TYPE_emsg = Util.getIntegerCodeForString("emsg");
+  public static final int TYPE_mfra = Util.getIntegerCodeForString("mfra");
+  public static final int TYPE_mfro = Util.getIntegerCodeForString("mfro");
+  public static final int TYPE_tfra = Util.getIntegerCodeForString("tfra");
   public static final int TYPE_DASHES = Util.getIntegerCodeForString("----");
 
   public final int type;


### PR DESCRIPTION
Without this patch, the player relies on the presence of an `sidx` box to build up a seek map when playing an mp4 container.

This patch adds support for `mfra`, `tfra`, and `mfro` boxes and uses them to build the seek map instread. Unfortunately, the `mfra` box is located at the _end_ of the file. Reading this rather efficiently will therefore only work for local files.

The feature is also not implemented in a very clean way. We need to expose the underlying `DataSource` in the `ExtractorInput` and then perform some type checks to find the source URI. If the source is indeed a local file, we open a _new_ `DataSource` on that file and look for the `mfro` box at the end of the file and then use the offset exposed there to find and read the full `mfra` box and build up the seek map.

 In addition, the `moof` boxes might miss presentation time information, so we extended the parsers to use the generated (extended) seek map to find the presentation time for a given `moof` and its samples.